### PR TITLE
Add pyqrcode to requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyotp
+pyqrcode
 requests


### PR DESCRIPTION
When trying to use `duo_export.py` it fails to find pyqrcode. Not ideal. 
I've added this to the requirements.