### PR TITLE
Pin dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-pyotp
-requests
+pyotp==2.3.0
+pyqrcode==1.2.1
+requests==2.22.0


### PR DESCRIPTION
Please merge #3 or amend this before merging. This PR also includes the user of pyqrcode.

Personally I prefer to pin versions so when installing users don't end up with mixed versions of dependencies which may lead to things breaking.